### PR TITLE
xd: others: Track arrow's mkbootimg

### DIFF
--- a/obsolete.xml
+++ b/obsolete.xml
@@ -113,5 +113,6 @@
   <remove-project name="platform/system/vold" />
   <remove-project name="platform/system/update_engine" />
   <remove-project name="platform/system/extras" />
+  <remove-project name="platform/system/tools/mkbootimg" />
 
 </manifest>

--- a/others.xml
+++ b/others.xml
@@ -95,5 +95,6 @@
   <project path="prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" name="PixelExperience/prebuilts_gcc_linux-x86_x86_x86_64-linux-android-4.9" remote="github" revision="twelve" clone-depth="1" />
   <project path="tools/extract-utils" name="android_tools_extract-utils" remote="lineage" />
   <project path="packages/resources/devicesettings" name="android_packages_resources_devicesettings" remote="lineage" />
+  <project path="system/tools/mkbootimg" name="android_system_tools_mkbootimg" remote="arrow" />
 
 </manifest>


### PR DESCRIPTION
Arrow's mkbootimg has a additional support for --dt option.
which some devices use. this will make building for other devices easier.